### PR TITLE
style(Acronyms): Add longest acronym to the acronym environment

### DIFF
--- a/thesis/chapters/20_lists.tex
+++ b/thesis/chapters/20_lists.tex
@@ -1,7 +1,6 @@
 \section*{Akronyme}            % Alternatively a glossary package can be used
 \addcontentsline{toc}{section}{Akronyme}
 \begin{acronym}[SAP IS-U]
-  \acro{acro}[ACRO]{Acronym}
   \acro{iot}[IOT]{Internet of Things}
   \acro{rest}[REST]{Representational State Transfer}
   \acro{mqtt}[MQTT]{Message Queuing Telemetry Transport}

--- a/thesis/chapters/20_lists.tex
+++ b/thesis/chapters/20_lists.tex
@@ -1,6 +1,6 @@
 \section*{Akronyme}            % Alternatively a glossary package can be used
 \addcontentsline{toc}{section}{Akronyme}
-\begin{acronym}[]
+\begin{acronym}[SAP IS-U]
   \acro{acro}[ACRO]{Acronym}
   \acro{iot}[IOT]{Internet of Things}
   \acro{rest}[REST]{Representational State Transfer}


### PR DESCRIPTION
Always provide the longest acronym to the `\begin{acronym}[]`
environment to get a proper indented acronym list.

```
Akronyme
IoT....Internet of Things
SAP IS-U....SAP Industry Solution for Utilities

Akronyme
IoT.........Internet of Things
SAP IS-U....SAP Industry Solution for Utilities
```

> Don't forget to rebuild the document to see these changes :)